### PR TITLE
Fix TOC metrics timestamp handling

### DIFF
--- a/src/shared/hooks/useTocMetrics.ts
+++ b/src/shared/hooks/useTocMetrics.ts
@@ -9,10 +9,17 @@ import {
 const useTocMetrics = (): void => {
   const location = useLocation();
   const fullPath = `${location.pathname}${location.search}`;
-  const initialPathRef = useRef(fullPath);
+  const initialPathRef = useRef<string | null>(null);
 
   useEffect(() => {
-    initializeTocMetrics(initialPathRef.current);
+    const resolvedInitialPath =
+      initialPathRef.current ??
+      (typeof window !== 'undefined'
+        ? `${window.location.pathname}${window.location.search}`
+        : '/');
+
+    initialPathRef.current = resolvedInitialPath;
+    initializeTocMetrics(resolvedInitialPath);
 
     return () => {
       shutdownTocMetrics({ flush: false });


### PR DESCRIPTION
## Summary
- sanitize page view timestamps using helper utilities so started and ended times are always valid and chronological when sending metrics
- initialize TOC metrics with the actual browser location to avoid registering redirects as zero-length page views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc253be6d88328acbd070873e02322