### PR TITLE
Add ingestion module with project upload form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ConsultaDatos from '@/pages/ConsultaDatos/ConsultaDatos';
 import Historial from '@/pages/Historial/Historial';
 import Proyecto from './pages/Proyecto/Proyecto';
 import LoginPage from './pages/auth/LoginPage';
+import Ingestion from './pages/Ingestion/Ingestion';
 
 function App() {
   useTocMetrics();
@@ -27,6 +28,7 @@ function App() {
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/consulta-datos" element={<ConsultaDatos />} />
                 <Route path="/proyecto" element={<Proyecto />} />
+                <Route path="/ingestion" element={<Ingestion />} />
                 <Route path="/historial" element={<Historial />} />
                 <Route
                   path="/"

--- a/src/pages/Ingestion/Ingestion.tsx
+++ b/src/pages/Ingestion/Ingestion.tsx
@@ -1,0 +1,213 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import DashboardLayout from '@shared/components/layout/DashboardLayout';
+import Card from '@shared/components/ui/Card';
+import Select from '@shared/components/ui/Select';
+import Input from '@shared/components/ui/Input';
+import Button from '@shared/components/ui/Button';
+import { useToast } from '@shared/contexts/ToastContext';
+import {
+  getIngestionProjects,
+  uploadIngestionDocument,
+  type Proyecto,
+} from '@shared/services/api';
+
+const ACCEPTED_EXTENSIONS = ['xlsx', 'csv'];
+
+const Ingestion: React.FC = () => {
+  const { showError, showSuccess, showWarning } = useToast();
+  const [projects, setProjects] = useState<Proyecto[]>([]);
+  const [isLoadingProjects, setIsLoadingProjects] = useState<boolean>(false);
+  const [selectedProjectId, setSelectedProjectId] = useState<string>('');
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [fileInputKey, setFileInputKey] = useState<number>(0);
+
+  const loadProjects = useCallback(async () => {
+    try {
+      setIsLoadingProjects(true);
+      const data = await getIngestionProjects();
+      setProjects(data);
+      setSelectedProjectId((current) => {
+        if (!current) {
+          return current;
+        }
+
+        const exists = data.some((project) => project.id === current);
+        return exists ? current : '';
+      });
+    } catch (error) {
+      console.error('Error al cargar proyectos para ingestión:', error);
+      showError(
+        'Error al cargar proyectos',
+        'No fue posible obtener la lista de proyectos disponibles.'
+      );
+    } finally {
+      setIsLoadingProjects(false);
+    }
+  }, [showError]);
+
+  useEffect(() => {
+    void loadProjects();
+  }, [loadProjects]);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] || null;
+
+    if (!file) {
+      setSelectedFile(null);
+      return;
+    }
+
+    const extension = file.name.split('.').pop()?.toLowerCase();
+
+    if (!extension || !ACCEPTED_EXTENSIONS.includes(extension)) {
+      showWarning(
+        'Formato no soportado',
+        'Solo se permiten archivos en formato .xlsx o .csv.'
+      );
+      setSelectedFile(null);
+      setFileInputKey((prev) => prev + 1);
+      return;
+    }
+
+    setSelectedFile(file);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedProjectId) {
+      showWarning(
+        'Proyecto requerido',
+        'Selecciona un proyecto antes de iniciar la ingestión.'
+      );
+      return;
+    }
+
+    if (!selectedFile) {
+      showWarning(
+        'Archivo requerido',
+        'Selecciona un archivo .xlsx o .csv para continuar.'
+      );
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await uploadIngestionDocument(selectedProjectId, selectedFile);
+      showSuccess(
+        'Ingestión iniciada',
+        'El archivo se ha enviado correctamente para su procesamiento.'
+      );
+      setSelectedFile(null);
+      setFileInputKey((prev) => prev + 1);
+    } catch (error: any) {
+      console.error('Error al enviar archivo de ingestión:', error);
+      const message =
+        error?.response?.data?.message ||
+        error?.message ||
+        'Ocurrió un error al procesar el archivo.';
+      showError('Error al enviar el archivo', message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const projectOptions = projects.map((project) => ({
+    value: project.id,
+    label: project.nombre,
+  }));
+
+  return (
+    <DashboardLayout title="Ingestión">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <Card>
+          <Card.Header>
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  Envío de archivos para ingestión
+                </h2>
+                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  Selecciona un proyecto con el filtro requerido y carga un archivo
+                  en formato .xlsx o .csv para iniciar el proceso de ingestión.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  void loadProjects();
+                }}
+                isLoading={isLoadingProjects}
+              >
+                Actualizar lista
+              </Button>
+            </div>
+          </Card.Header>
+          <Card.Content>
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <Select
+                  label="Proyecto"
+                  value={selectedProjectId}
+                  onChange={(event) => setSelectedProjectId(event.target.value)}
+                  options={projectOptions}
+                  placeholder={
+                    isLoadingProjects
+                      ? 'Cargando proyectos...'
+                      : 'Selecciona un proyecto'
+                  }
+                  disabled={isLoadingProjects || projects.length === 0}
+                  required
+                  helperText="Los proyectos se consultan usando el filtro nombre=Proyecto."
+                />
+                <Input
+                  key={fileInputKey}
+                  type="file"
+                  label="Documento"
+                  accept=".xlsx,.csv"
+                  onChange={handleFileChange}
+                  className="cursor-pointer file:mr-4 file:rounded-md file:border-0 file:bg-blue-600 file:px-4 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-blue-700 dark:file:bg-blue-500 dark:hover:file:bg-blue-600"
+                  helperText="Formatos soportados: archivos .xlsx o .csv."
+                  required
+                />
+              </div>
+
+              {selectedFile && (
+                <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
+                  <p className="font-medium">Archivo listo para enviar</p>
+                  <p className="mt-1 break-all">{selectedFile.name}</p>
+                </div>
+              )}
+
+              {!isLoadingProjects && projects.length === 0 && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">
+                  No se encontraron proyectos disponibles con el filtro solicitado.
+                </div>
+              )}
+
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  isLoading={isSubmitting}
+                  disabled={
+                    isSubmitting ||
+                    !selectedProjectId ||
+                    !selectedFile ||
+                    isLoadingProjects
+                  }
+                >
+                  Iniciar ingestión
+                </Button>
+              </div>
+            </form>
+          </Card.Content>
+        </Card>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Ingestion;

--- a/src/shared/components/layout/Sidebar.tsx
+++ b/src/shared/components/layout/Sidebar.tsx
@@ -45,6 +45,25 @@ const Sidebar: React.FC<SidebarProps> = ({
       ),
     },
     {
+      name: 'Ingestion',
+      path: '/ingestion',
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5-5m0 0l5 5m-5-5v12"
+          />
+        </svg>
+      ),
+    },
+    {
       name: 'Proyecto',
       path: '/proyecto',
       icon: (

--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -413,6 +413,42 @@ export const getProyectosList = async (
   return response.results;
 };
 
+export const getIngestionProjects = async (): Promise<Proyecto[]> => {
+  try {
+    const response = await getProyectos({ nombre: 'Proyecto', page_size: 1000 });
+    return response.results;
+  } catch (error) {
+    console.error('Error obteniendo proyectos para ingestión:', error);
+    throw error;
+  }
+};
+
+export const uploadIngestionDocument = async (
+  proyectoId: string,
+  file: File
+): Promise<any> => {
+  try {
+    const formData = new FormData();
+    formData.append('documento', file);
+    formData.append('proyecto_id', proyectoId);
+
+    const response = await apiClient.post(
+      `/api/ingestion/?proyecto=${encodeURIComponent(proyectoId)}`,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error('Error subiendo documento de ingestión:', error);
+    throw error;
+  }
+};
+
 export const createProyecto = async (
   proyecto: Omit<Proyecto, 'id' | 'created_at' | 'modified_at'>
 ): Promise<Proyecto> => {
@@ -805,6 +841,8 @@ export const apiService = {
 
   getProyectos,
   getProyectosList,
+  getIngestionProjects,
+  uploadIngestionDocument,
   createProyecto,
   updateProyecto,
   deleteProyecto,


### PR DESCRIPTION
## Summary
- add an Ingestion dashboard page with a project selector, upload validation and submission flow
- expose API helpers to list filtered projects and send ingestion files to the backend
- register the new module in the router and sidebar navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdcc4a7128832890811001b67d0377