### PR TITLE
Integrate ingestion results retrieval into ingestion results page

### DIFF
--- a/src/pages/Historial/components/TablaHistorial.tsx
+++ b/src/pages/Historial/components/TablaHistorial.tsx
@@ -103,7 +103,7 @@ export const TablaHistorial = ({
         hour: '2-digit',
         minute: '2-digit',
       });
-    } catch (error) {
+    } catch {
       return 'Error en fecha de creación';
     }
   };

--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -461,6 +461,49 @@ export const uploadIngestionDocument = async (
   }
 };
 
+export interface IngestionResultItem {
+  id: string;
+  tipo?: string | null;
+  titulo?: string | null;
+  contenido: string;
+  fecha?: string | null;
+  autor?: string | null;
+  reach?: number | null;
+  engagement?: number | null;
+  url?: string | null;
+  red_social?: string | null;
+  proyecto?: string | null;
+  proyecto_nombre?: string | null;
+  emojis?: string[];
+  mensaje?: string | null;
+  mensaje_formateado?: string | null;
+}
+
+export const getIngestionResults = async (
+  proyectoId: string
+): Promise<IngestionResultItem[]> => {
+  if (!proyectoId.trim()) {
+    return [];
+  }
+
+  try {
+    const response = await apiClient.get(
+      `/api/ingestion/?proyecto=${encodeURIComponent(proyectoId)}`
+    );
+
+    const data = response.data;
+
+    if (Array.isArray(data)) {
+      return data;
+    }
+
+    return data ? [data] : [];
+  } catch (error) {
+    console.error('Error obteniendo resultados de ingestión:', error);
+    throw error;
+  }
+};
+
 export const createProyecto = async (
   proyecto: Omit<Proyecto, 'id' | 'created_at' | 'modified_at'>
 ): Promise<Proyecto> => {


### PR DESCRIPTION
## Summary
- add an API helper to retrieve ingestion results for a specific proyecto
- refactor the ingestion results view to request live data, allow proyecto selection, and show every registro in a single table while preserving emoji and edición features
- tidy the historial table catch block to avoid an unused variable warning

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a0fdf44483339f29b856cc154166