### PR TITLE
Redirect ingestion results after upload

### DIFF
--- a/src/pages/Ingestion/Ingestion.tsx
+++ b/src/pages/Ingestion/Ingestion.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import DashboardLayout from '@shared/components/layout/DashboardLayout';
 import Card from '@shared/components/ui/Card';
 import Input from '@shared/components/ui/Input';
@@ -13,6 +14,7 @@ import {
 const ACCEPTED_EXTENSIONS = ['xlsx', 'csv'];
 
 const Ingestion: React.FC = () => {
+  const navigate = useNavigate();
   const { showError, showSuccess, showWarning } = useToast();
   const [projectSearchTerm, setProjectSearchTerm] = useState<string>('');
   const [projects, setProjects] = useState<Proyecto[]>([]);
@@ -149,13 +151,25 @@ const Ingestion: React.FC = () => {
 
     try {
       setIsSubmitting(true);
-      await uploadIngestionDocument(selectedProjectId, selectedFile);
+      const response = await uploadIngestionDocument(
+        selectedProjectId,
+        selectedFile
+      );
+
       showSuccess(
         'Ingestión iniciada',
         'El archivo se ha enviado correctamente para su procesamiento.'
       );
       setSelectedFile(null);
       setFileInputKey((prev) => prev + 1);
+
+      navigate('/ingestion/resultados', {
+        state: {
+          ingestionResponse: response,
+          projectId: selectedProjectId,
+          projectName: selectedProjectName,
+        },
+      });
     } catch (error: any) {
       console.error('Error al enviar archivo de ingestión:', error);
       const message =


### PR DESCRIPTION
## Summary
- navigate to the ingestion results page after a successful upload, passing the API response data
- hydrate the ingestion results view from the navigation payload and skip the API request when the response is provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a72e5d98833395a0468ae34480a5