### PR TITLE
feat: add manual ingestion workflow

### DIFF
--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -447,6 +447,28 @@ export const uploadIngestionDocument = async (
   }
 };
 
+export const triggerManualIngestion = async (
+  proyectoId: string,
+  url: string
+): Promise<any> => {
+  try {
+    const payload = {
+      proyecto_id: proyectoId,
+      url,
+    };
+
+    const response = await apiClient.post(
+      `/api/ingestion/manual/?proyecto=${encodeURIComponent(proyectoId)}`,
+      payload
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error('Error iniciando ingestión manual:', error);
+    throw error;
+  }
+};
+
 export interface IngestionResultItem {
   id: string;
   tipo?: string | null;


### PR DESCRIPTION
## Summary
- add a manual ingestion modal that mirrors the project search flow and validates manual URLs
- surface a button in the ingestion view to open the manual alert form and reuse the ingestion success navigation
- add an API helper to trigger manual ingestions against the backend endpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1cc0f0f84833394bb6eea0292b528