### PR TITLE
Handle null text in highlightKeywords to prevent runtime error

### DIFF
--- a/src/pages/ConsultaDatos/ConsultaDatos.tsx
+++ b/src/pages/ConsultaDatos/ConsultaDatos.tsx
@@ -802,10 +802,15 @@ const ConsultaDatos: React.FC = () => {
     return new Intl.NumberFormat('es-ES').format(num);
   };
 
-  const highlightKeywords = (text: string, keywords: string[] = []) => {
-    if (!keywords || keywords.length === 0) return text;
+  const highlightKeywords = (
+    text: string | null | undefined,
+    keywords: string[] = []
+  ) => {
+    const safeText = text ?? '';
+    if (!safeText) return '';
+    if (!keywords || keywords.length === 0) return safeText;
 
-    let highlightedText = text;
+    let highlightedText = safeText;
 
     keywords.forEach((keyword) => {
       if (keyword && keyword.trim()) {

--- a/src/pages/ConsultaDatos/components/DataTable.tsx
+++ b/src/pages/ConsultaDatos/components/DataTable.tsx
@@ -39,7 +39,7 @@ interface DataTableProps {
   onRemoveEmoji: (itemId: string, emojiIndex: number) => void;
   onEditItem: (item: any) => void;
   onPreviewItem: (item: any) => void;
-  highlightKeywords: (text: string, keywords: string[]) => string;
+  highlightKeywords: (text: string | null | undefined, keywords: string[]) => string;
 }
 
 const DataTable: React.FC<DataTableProps> = ({

--- a/src/pages/Ingestion/IngestionResultado.tsx
+++ b/src/pages/Ingestion/IngestionResultado.tsx
@@ -383,10 +383,15 @@ const IngestionResultado: React.FC = () => {
   const formatNumber = (num: number) =>
     new Intl.NumberFormat('es-ES', { notation: 'compact' }).format(num);
 
-  const highlightKeywords = (text: string, keywords: string[] = []) => {
-    if (!keywords || keywords.length === 0) return text;
+  const highlightKeywords = (
+    text: string | null | undefined,
+    keywords: string[] = []
+  ) => {
+    const safeText = text ?? '';
+    if (!safeText) return '';
+    if (!keywords || keywords.length === 0) return safeText;
 
-    let highlightedText = text;
+    let highlightedText = safeText;
 
     keywords.forEach((keyword) => {
       if (keyword && keyword.trim()) {


### PR DESCRIPTION
## Summary
- ensure highlightKeywords gracefully handles null or undefined text values in ConsultaDatos and ingestion results
- update DataTable prop typing to reflect relaxed input requirements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1d4a519cc83339872fe2ea2ce51ad