### PR TITLE
Update ingestion upload request to use multipart form data

### DIFF
--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -428,20 +428,20 @@ export const uploadIngestionDocument = async (
   proyectoId: string,
   file: File
 ): Promise<any> => {
-  try {
-    const formData = new FormData();
-    formData.append('file', file);
-    formData.append('proyecto_id', proyectoId);
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('proyecto_id', proyectoId);
 
-    const response = await apiClient.post(
-      buildIngestionEndpoint(proyectoId),
-      formData,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      }
-    );
+  try {
+    const response = await apiClient.post('/api/ingestion/', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
+    setTimeout(() => {
+      window.location.href = '/ingestion/resultados';
+    }, 0);
 
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- update `uploadIngestionDocument` to send FormData with proyecto_id and file via multipart/form-data
- trigger redirect to /ingestion/resultados after a successful upload and log errors on failure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e607c88483339cf3141910ef91cc