### PR TITLE
Fix ingestion upload endpoint

### DIFF
--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -433,11 +433,15 @@ export const uploadIngestionDocument = async (
   formData.append('proyecto_id', proyectoId);
 
   try {
-    const response = await apiClient.post('/api/ingestion/', formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    const response = await apiClient.post(
+      buildIngestionEndpoint(proyectoId),
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    );
 
     setTimeout(() => {
       window.location.href = '/ingestion/resultados';


### PR DESCRIPTION
## Summary
- send file ingestion requests to the project-scoped endpoint so they include the proyecto query parameter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ecf08ba08333bdb0016960d33cec