### PR TITLE
Fix ingestion document upload payload

### DIFF
--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -430,18 +430,8 @@ export const uploadIngestionDocument = async (
 ): Promise<any> => {
   const formData = new FormData();
   formData.append('file', file);
-  formData.append('proyecto_id', proyectoId);
-
-  const defaultHeaders = apiClient.defaults.headers.common;
-  const hadContentType =
-    !!defaultHeaders && Object.prototype.hasOwnProperty.call(defaultHeaders, 'Content-Type');
-  const previousContentType = hadContentType ? defaultHeaders['Content-Type'] : undefined;
 
   try {
-    if (hadContentType) {
-      delete defaultHeaders['Content-Type'];
-    }
-
     const response = await apiClient.post(
       buildIngestionEndpoint(proyectoId),
       formData
@@ -455,10 +445,6 @@ export const uploadIngestionDocument = async (
   } catch (error) {
     console.error('Error subiendo documento de ingestión:', error);
     throw error;
-  } finally {
-    if (hadContentType) {
-      defaultHeaders['Content-Type'] = previousContentType;
-    }
   }
 };
 


### PR DESCRIPTION
## Summary
- stop sending the project identifier inside the ingestion upload form data
- rely on Axios to set the multipart boundary automatically by removing custom Content-Type handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ae19cf808333b41b817ac308d6b1