### PR TITLE
Refine API client headers handling

### DIFF
--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -88,13 +88,11 @@ export interface HistorialPaginationParams {
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
 });
 
 apiClient.interceptors.request.use(
   async (config) => {
+    config.headers = config.headers ?? {};
     const token = getAccessToken();
 
     if (token) {


### PR DESCRIPTION
## Summary
- remove the default JSON content-type header from the shared Axios client so uploads can rely on Axios boundary handling
- simplify the request interceptor to only attach the bearer token while leaving header management to Axios

## Testing
- npm run lint *(fails: existing lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b11612a883339625bb084f340f3c